### PR TITLE
Use `find` to strip debug symbols safely (LLVM)

### DIFF
--- a/2-llvmtools/36-Stripping_and_Ownership
+++ b/2-llvmtools/36-Stripping_and_Ownership
@@ -6,14 +6,14 @@
 # of unneeded debugging symbols. 
 
 # Remove debug symbols with: 
-strip --strip-debug /llvmtools/lib/*
-/usr/bin/strip --strip-unneeded /llvmtools/bin/*
+find /llvmtools/lib/ -maxdepth 1 -type f -exec strip --strip-debug {} \;
+find /llvmtools/bin/ -maxdepth 1 -type f -exec /cgnutools/bin/llvm-strip --strip-unneeded {} \;
 
 # Remove the documentation:
 rm -rf /llvmtools/{,share}/{info,man,doc}
 
 # Remove unneeded files:
-find /llvmtools/{lib,libexec} -name \*.la -delete
+find /llvmtools/{lib,libexec} -name \*.la -exec rm -rfv {} \;
 
 # Changing Ownership 
 # Currently, the $MLFS/tools directory is owned by 


### PR DESCRIPTION
Since `llvm-strip` will stop when using recursive target a.k.a asterisk '*', if first file or directory reported 
"The file was not recognized as a valid object file" the next file will never stripped.