### PR TITLE
llvmtools: Use Cmake options instead of modifying Cmake files for removing `libatomic` detection

### DIFF
--- a/2-llvmtools/04-libcxx
+++ b/2-llvmtools/04-libcxx
@@ -7,10 +7,6 @@ export  CC=${CMLFS_TARGET}-clang
 
 cd ${LLVMSRC}/projects/libcxx
 
-# Remove libatomic detection, as libatomic is from GCC
-sed -i '/check_library_exists(atomic __atomic_fetch_add_8 "" LIBCXX_HAS_ATOMIC_LIB)/d' \
-${LLVMSRC}/projects/libcxx/cmake/config-ix.cmake
-
 # Configure
 cmake -B build  \
       -DCMAKE_INSTALL_PREFIX=/llvmtools \
@@ -22,6 +18,7 @@ cmake -B build  \
       -DLIBCXX_ENABLE_STATIC=ON  \
       -DLIBCXX_HAS_MUSL_LIBC=ON \
       -DLIBCXX_USE_COMPILER_RT=ON \
+      -DLIBCXX_HAS_ATOMIC_LIB=OFF \
       -DLIBCXX_CXX_ABI=libcxxabi \
       -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/llvmtools/include" \
       -DLIBCXX_CXX_ABI_LIBRARY_PATH="/llvmtools/lib" \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ CMLFS can either mean "Clang-built Musl Linux from Scratch" or "Clang MLFS". It 
  <li>Ninja/Samurai</li>
  <li>wget/cURL</li>
 </ul>
-# Required Base Development tools (may refer to LFS)
+
+## Required Base Development tools (may refer to LFS)
 <ul>
  <li>bash 3.2 (/bin/sh should be a symbolic or hard link to bash) </li>
  <li>binutils 2.25 </li>


### PR DESCRIPTION
After figuring out, I found this. 😄 