### PR TITLE
Propose download_sources.sh usage as an alternative to the wget command line.

### DIFF
--- a/0-Preparation
+++ b/0-Preparation
@@ -45,7 +45,9 @@ ln -sv   $CMLFS/llvmtools /
 mkdir -pv $CMLFS/sources/{patches,files,pkgs}
 
 # Download sources. Provided list can be used with wget:
-wget --input-file=source.list --continue --directory-prefix=$CMLFS/sources/pkgs
+#wget --input-file=sources.list --continue --directory-prefix=$CMLFS/sources/pkgs
+# or use the download_sources.sh script if you have only cURL ;^]
+./download_sources.sh sources.list sources.md5
 
 # Create user and group:
 # As root, change ownership to allow installation of tools

--- a/download_sources.sh
+++ b/download_sources.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Simple shell hack to download and MD5 check source tarballs.
+# Copyright 2021: Luiz Antônio (takusuman).
+# This particular script is dual-licensed between BSD 2-Clause
+# or GPL3, at your preference.
+# n() function taken from otto-pkg's posix-alt.shi lib.
+# Imported from Musl-LFS.
+
+# USAGE: ./download_sources.sh sources.list sources.md5
+
+MD5CHECK=${MD5CHECK:-YES};
+CMLFS=${CMLFS:-/mnt/cmlfs};
+SRCDIR=${SRCDIR:-$CMLFS/sources/pkgs};
+
+# Workaround to the # macro in arrays
+# which doesn't work properly in bash 4.3 for some reason.
+n(){
+	echo ${@} | tr " " "\n" | wc -l;
+}
+
+main(){
+	PARENTDIR=${PWD};
+	test ! -e ${SRCDIR} && mkdir ${SRCDIR};
+	urls=( `cat ${1} | tr "\n" " "` );
+	n_urls=`n ${urls[*]}`;
+	cd src;
+	for (( i=0; i < ${n_urls}; i++ )){
+		printf '%s\n' "Downloading $(basename ${urls[${i}]})";
+		curl -L ${urls[${i}]} -O;
+	}
+	[ ${MD5CHECK} == 'YES' ] &&
+	md5sum -c ${PARENTDIR}/${2};
+	cd ${PARENTDIR};
+	return 0;
+}
+
+main "${1}" "${2}";


### PR DESCRIPTION
I've ported the download_sources.sh script to work more flexibly and proper with the CMLFS. Basically, i've added the possibility to download sources where you'd want, but with /mnt/cmlfs/sources/pkgs as default.

I didn't too much in this weekend because i've needed to study to finals (i've had physics yesterday and i couldn't lose the chance to get a good grade in it).

May i'll "convert" the plain-text/markdown manual to HTML at the end of this week (and of the finals).