### PR TITLE
Portabilize `find` call at 1-kernel-headers

### DIFF
--- a/1-cgnutools/1-kernel-headers
+++ b/1-cgnutools/1-kernel-headers
@@ -11,7 +11,7 @@ make mrproper
 ARCH=${CMLFS_ARCH} make headers
 
 # Install the headers
-find usr/include \( -name .install -o -name ..install.cmd \) -delete
+find usr/include \( -name .install -o -name ..install.cmd \) -exec rm -vf {} \;
 mkdir -pv /cgnutools/${CMLFS_TARGET}/include
 cp -rv usr/include/* /cgnutools/${CMLFS_TARGET}/include/
 rm -v /cgnutools/${CMLFS_TARGET}/include/Makefile

--- a/1-cgnutools/3-GCC-static
+++ b/1-cgnutools/3-GCC-static
@@ -16,7 +16,7 @@ mkdir -v build && cd  build
 
 # Configure source 
 CFLAGS='-g0 -O0' \
-CXXFLAGS='-g0 -O0' \
+CXXFLAGS=$CFLAGS \
 ../configure \
   --prefix=/cgnutools --build=${CMLFS_HOST} \
   --host=${CMLFS_HOST}   --target=${CMLFS_TARGET} \

--- a/1-cgnutools/4-musl
+++ b/1-cgnutools/4-musl
@@ -26,9 +26,9 @@ mkdir /cgnutools/etc
 ln -sv ../lib/libc.so /cgnutools/bin/ldd
 
 # Configure the dynamic linker
-cat > /cgnutools/etc/ld-musl-x86_64.path << "EOF"
+cat > /cgnutools/etc/ld-musl-$CMLFS_CPU.path << "EOF"
 /cgnutools/lib
-/cgnutools/x86_64-cmlfs-linux-musl/lib
+/cgnutools/${CMLFS_TARGET}/lib
 /usr/lib
 /lib
 EOF

--- a/1-cgnutools/8-clang
+++ b/1-cgnutools/8-clang
@@ -68,8 +68,9 @@ mkdir -pv tools/lld/include/mach-o
 cp -v projects/libunwind/include/mach-o/compact_unwind_encoding.h tools/lld/include/mach-o
 
 # Set flags to greatly reduce debugging symbols
-export CFLAGS=" -g -g1"
-export CXXFLAGS=" -g -g1" 
+CFLAGS=' -g -g1'
+CXXFLAGS=$CFLAGS 
+export CFLAGS CXXFLAGS
 
 # Update host/target triple detection
 cp -v ../files/config.guess-musl cmake/config.guess

--- a/1-cgnutools/8-clang
+++ b/1-cgnutools/8-clang
@@ -13,44 +13,52 @@ cd ${LLVMSRC}
 # make sure compiler-rt, libcxx, libcxxabi, libunwind are unpacked in ${{LLVMSRC}/projects
 # and clang & lld in ${LLVMSRC}/tools.
 cd projects && \
-tar xf ../../pkgs/compiler-rt-12.0.0.src.tar.xz && \
-mv compiler-rt-12.0.0.src compiler-rt           && \
-tar xf ../../pkgs/libcxx-12.0.0.src.tar.xz      && \
-mv libcxx-12.0.0.src libcxx                     && \
-tar xf ../../pkgs/libcxxabi-12.0.0.src.tar.xz   && \
-mv libcxxabi-12.0.0.src libcxxabi               && \
-tar xf ../../pkgs/libunwind-12.0.0.src.tar.xz   && \
-mv libunwind-12.0.0.src libunwind               && \
-cd ${LLVMSRC}/tools && \
-tar xf ../../pkgs/clang-12.0.0.src.tar.xz 
-mv clang-12.0.0.src clang
-tar xf ../../pkgs/lld-12.0.0.src.tar.xz 
+xz -cd ../../pkgs/compiler-rt-12.0.0.src.tar.xz | tar xf - && \
+mv compiler-rt-12.0.0.src compiler-rt           	   && \
+xz -cd ../../pkgs/libcxx-12.0.0.src.tar.xz | tar xf -	   && \
+mv libcxx-12.0.0.src libcxx                     	   && \
+xz -cd ../../pkgs/libcxxabi-12.0.0.src.tar.xz | tar xf -   && \
+mv libcxxabi-12.0.0.src libcxxabi 			   && \
+xz -cd ../../pkgs/libunwind-12.0.0.src.tar.xz | tar xf -   && \
+mv libunwind-12.0.0.src libunwind               	   && \
+cd ${LLVMSRC}/tools 					   && \
+xz -cd ../../pkgs/clang-12.0.0.src.tar.xz | tar xf -	   && \
+mv clang-12.0.0.src clang				   && \
+xz -cd ../../pkgs/lld-12.0.0.src.tar.xz | tar xf - 	   && \
 mv lld-12.0.0.src lld
 
 # Apply patches from void linux
 cd ${LLVMSRC}/projects/compiler-rt
-patch -Np1 -i ../../../patches/llvm12-compiler-rt-void/compiler-rt-aarch64-ucontext.patch
-patch -Np1 -i ../../../patches/llvm12-compiler-rt-void/compiler-rt-sanitizer-ppc64-musl.patch
-patch -Np1 -i ../../../patches/llvm12-compiler-rt-void/compiler-rt-size_t.patch 
-patch -Np1 -i ../../../patches/llvm12-compiler-rt-void/compiler-rt-xray-ppc64-musl.patch
+for i in ../../../patches/llvm12-compiler-rt-void/compiler-rt-aarch64-ucontext.patch \
+	../../../patches/llvm12-compiler-rt-void/compiler-rt-sanitizer-ppc64-musl.patch \
+	../../../patches/llvm12-compiler-rt-void/compiler-rt-size_t.patch \
+	../../../patches/llvm12-compiler-rt-void/compiler-rt-xray-ppc64-musl.patch; do
+	patch -Np1 -i $i 
+done
 cd ${LLVMSRC}/projects/libcxx
-patch -Np1 -i ../../../patches/llvm12-libcxx-void/libcxx-musl.patch 
-patch -Np1 -i ../../../patches/llvm12-libcxx-void/libcxx-ppc.patch 
-patch -Np1 -i ../../../patches/llvm12-libcxx-void/libcxx-ssp-nonshared.patch 
+for i in ../../../patches/llvm12-libcxx-void/libcxx-musl.patch \
+	../../../patches/llvm12-libcxx-void/libcxx-ppc.patch \ 
+	../../../patches/llvm12-libcxx-void/libcxx-ssp-nonshared.patch; do
+	patch -Np1 -i $i 
+done
 cd ${LLVMSRC}/projects/libunwind
 patch -Np1 -i ../../../patches/llvm12-libunwind-void/libunwind-ppc32.patch
 cd ${LLVMSRC}/tools/clang
-patch -Np1 -i ../../../patches/llvm12-clang-void/clang-001-fix-unwind-chain-inclusion.patch 
-patch -Np1 -i ../../../patches/llvm12-clang-void/clang-002-add-musl-triples.patch 
-patch -Np1 -i ../../../patches/llvm12-clang-void/clang-003-ppc64-dynamic-linker-path.patch 
-patch -Np1 -i ../../../patches/llvm12-clang-void/clang-004-ppc64-musl-elfv2.patch
+for i in ../../../patches/llvm12-clang-void/clang-001-fix-unwind-chain-inclusion.patch \
+	../../../patches/llvm12-clang-void/clang-002-add-musl-triples.patch \
+	../../../patches/llvm12-clang-void/clang-003-ppc64-dynamic-linker-path.patch \
+ 	../../../patches/llvm12-clang-void/clang-004-ppc64-musl-elfv2.patch; do
+	patch -Np1 -i $i
+done
 cd ${LLVMSRC}
-patch  -Np1 -i ../patches/llvm12-void/llvm-001-musl.patch
-patch  -Np1 -i ../patches/llvm12-void/llvm-002-musl-ppc64-elfv2.patch 
-patch  -Np1 -i ../patches/llvm12-void/llvm-003-ppc-secureplt.patch 
-patch  -Np1 -i ../patches/llvm12-void/llvm-004-override-opt.patch
-patch  -Np1 -i ../patches/llvm12-void/llvm-005-ppc-bigpic.patch
-patch  -Np1 -i ../patches/llvm12-void/llvm-006-aarch64-mf_exec.patch 
+for i in ../patches/llvm12-void/llvm-001-musl.patch \ 
+	../patches/llvm12-void/llvm-002-musl-ppc64-elfv2.patch \
+	../patches/llvm12-void/llvm-003-ppc-secureplt.patch \
+	../patches/llvm12-void/llvm-004-override-opt.patch \
+	../patches/llvm12-void/llvm-005-ppc-bigpic.patch \
+	../patches/llvm12-void/llvm-006-aarch64-mf_exec.patch; do
+	patch  -Np1 -i $i
+done
 
 # Disable sanitizers for musl systems, per Void Linux... fixes early build failure
 sed -i 's/set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)/set(COMPILER_RT_HAS_SANITIZER_COMMON FALSE)/' projects/compiler-rt/cmake/config-ix.cmake

--- a/extra/alt/cgnutools_7a-netbsd-curses
+++ b/extra/alt/cgnutools_7a-netbsd-curses
@@ -1,0 +1,27 @@
+# cgnutools: netbsd-curses
+# source tarball: http://ftp.barfooze.de/pub/sabotage/tarballs/netbsd-curses-0.3.2.tar.xz
+# note: this is experimental, i'm not sure if it will work or just broke my
+# toolchain.
+# Build as cmlfs
+
+# Configure source with freshly build GCC, PREFIX and DESTDIR (it will be your
+# CMLFS root if you followed the steps at 0-Preparation correctly)
+cat > config.mak << "EOF"
+CC="${CMLFS_TARGET}-gcc"
+CXX="${CMLFS_TARGET}-g++"
+AR="${CMLFS_TARGET}-ar"
+AS="${CMLFS_TARGET}-as"
+RANLIB="${CMLFS_TARGET}-ranlib"
+LD="${CMLFS_TARGET}-ld"
+STRIP="${CMLFS_TARGET}-strip"
+
+PREFIX=/cgnutools
+DESTDIR="${CMLFS}"
+
+EOF
+
+# Build all the targets (both static and dynamic/shared libraries)
+make all
+
+# Install
+make install


### PR DESCRIPTION
## Portabilize `find` call at 1-kernel-headers

Change `-delete` for `-exec rm -vf {} \;`

## Removed unnecessary repetition when declaring *`FLAGS` at 3-GCC-static.

Just made `CXXFLAGS` point to/replicate directly `CFLAGS` instead of re-declarating its value. It's not a big deal, but this change avoid mistypings that could broke the `configure` stage.

## Relativize CPU architecture and cross-compilation target at 4-musl

Just in case of someone trying to port CMLFS to other architectures and don't wanting to have troubles when configurating musl (`/etc/ld-musl-$CMLFS_ARCH.path` et cetera) for `cgnutools`.

## ^Propose an `extra/alt` directory for alternative to common/overused programs in the base system.

I ^propose sabotage's netbsd-curses as an experimental alternative to GNU ncurses.

It compiles faster on my laptop with the `-j2` flag; it's small and suitable to embedded systems, like musl. :^)

## Portabilize tar calls for sane implementations and made `for` loops for patching clang at 8-clang

I hope i didn't broke anything when doing the `for`'s...

## Remove unnecessary repetition when declaring *`FLAGS` at 8-clang.
