### PR TITLE
add wildcard to match the correct file

### DIFF
--- a/1-Stage0/1-Mussel
+++ b/1-Stage0/1-Mussel
@@ -64,7 +64,7 @@ rm -rf  /cgnutools/share/man
 #
 # This will be reached by creating a modified  specs  file in the
 # proper location:
-export MCGV=$(/cgnutools/bin/gcc  --version | sed 1q | cut -d' ' -f3- )
+export MCGV=$(/cgnutools/bin/*gcc  --version | sed 1q | cut -d' ' -f3- )
 /cgnutools/bin/${TARGET_TUPLE}-gcc -dumpspecs | sed 's/\/lib\/ld-musl/\/cgnutools\/lib\/ld-musl/g' > /cgnutools/lib/gcc/${TARGET_TUPLE}/$MCGV/specs
 
 # Test the _tools toolchain:


### PR DESCRIPTION
There is no file or link as: /cgnutools/bin/gcc/
`bash: /cgnutools/bin/gcc: No such file or directory`

All of the files in /cgnutools/bin/ has this prefix: "x86_64-pc-linux-musl-"

So the wildcard will match "x86_64-pc-linux-musl-gcc"